### PR TITLE
chore(cn): 调整了当处于国内环境下的网络检测条件

### DIFF
--- a/scripts/install_pve.sh
+++ b/scripts/install_pve.sh
@@ -793,7 +793,11 @@ fi
 
 # 预检查
 if [ ! -f /etc/debian_version ] || [ $(grep MemTotal /proc/meminfo | awk '{print $2}') -lt 2000000 ] || [ $(grep -c ^processor /proc/cpuinfo) -lt 2 ] || [ $(
-    ping -c 3 google.com >/dev/null 2>&1
+    if [[ "${CN}" == true ]]; then
+        ping -c 3 baidu.com >/dev/null 2>&1
+    else
+        ping -c 3 google.com >/dev/null 2>&1
+    fi
     echo $?
 ) -ne 0 ]; then
     _red "Error: This system does not meet the minimum requirements for Proxmox VE installation."


### PR DESCRIPTION
当前在国内环境下运行 install_pve.sh 脚本，会无法通过最低要求检查，这是因为有一条 ping google.com 的判断，我调整了这个判断标准，当 CN=true时ping baidu即可